### PR TITLE
chore: prepare 1.0.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "markdown-parser-py"
-version = "1.0.0"
+version = "1.0.1"
 description = "Parse, Manipulate, and Merge Markdown Heading Trees Programmatically."
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ wheels = [
 
 [[package]]
 name = "markdown-parser-py"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "regex" },


### PR DESCRIPTION
@VarunGumma this is required before creating the tag that launches the release, because as you can see in [the job result that failed](https://github.com/VarunGumma/markdown-parser-py/actions/runs/17938881657/job/51010722452), the error message was:
> File already exists ('markdown_parser_py-1.0.0-py3-none-any.whl'

So for this 1.0.1 release to work, you have to delete the `1.0.1` tag, merge this PR, then re-create the `1.0.1` tag.

Then you should check the `Enable release immutability Loading` checkbox in the repository settings (read why and what is it on [Github blog post](https://github.blog/changelog/2025-08-26-releases-now-support-immutability-in-public-preview/))